### PR TITLE
Translate 5 file from Plugins

### DIFF
--- a/Plugins/IMAP.go
+++ b/Plugins/IMAP.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// IMAPScan 主扫描函数
+// IMAPScan main scan function
 func IMAPScan(info *Common.HostInfo) (tmperr error) {
 	if Common.DisableBrute {
 		return
@@ -20,10 +20,10 @@ func IMAPScan(info *Common.HostInfo) (tmperr error) {
 	maxRetries := Common.MaxRetries
 	target := fmt.Sprintf("%v:%v", info.Host, info.Ports)
 
-	Common.LogDebug(fmt.Sprintf("开始扫描 %s", target))
+	Common.LogDebug(fmt.Sprintf("Starting scan %s", target))
 	totalUsers := len(Common.Userdict["imap"])
 	totalPass := len(Common.Passwords)
-	Common.LogDebug(fmt.Sprintf("开始尝试用户名密码组合 (总用户数: %d, 总密码数: %d)", totalUsers, totalPass))
+	Common.LogDebug(fmt.Sprintf("Starting username and password combinations (Total users: %d, Total passwords: %d)", totalUsers, totalPass))
 
 	tried := 0
 	total := totalUsers * totalPass
@@ -32,11 +32,11 @@ func IMAPScan(info *Common.HostInfo) (tmperr error) {
 		for _, pass := range Common.Passwords {
 			tried++
 			pass = strings.Replace(pass, "{user}", user, -1)
-			Common.LogDebug(fmt.Sprintf("[%d/%d] 尝试: %s:%s", tried, total, user, pass))
+			Common.LogDebug(fmt.Sprintf("[%d/%d] Trying: %s:%s", tried, total, user, pass))
 
 			for retryCount := 0; retryCount < maxRetries; retryCount++ {
 				if retryCount > 0 {
-					Common.LogDebug(fmt.Sprintf("第%d次重试: %s:%s", retryCount+1, user, pass))
+					Common.LogDebug(fmt.Sprintf("Retry %d: %s:%s", retryCount+1, user, pass))
 				}
 
 				done := make(chan struct {
@@ -60,10 +60,10 @@ func IMAPScan(info *Common.HostInfo) (tmperr error) {
 				case result := <-done:
 					err = result.err
 					if result.success {
-						successMsg := fmt.Sprintf("IMAP服务 %s 爆破成功 用户名: %v 密码: %v", target, user, pass)
+						successMsg := fmt.Sprintf("IMAP service %s brute-forced successfully Username: %v Password: %v", target, user, pass)
 						Common.LogSuccess(successMsg)
 
-						// 保存结果
+						// Save result
 						vulnResult := &Common.ScanResult{
 							Time:   time.Now(),
 							Type:   Common.VULN,
@@ -81,11 +81,11 @@ func IMAPScan(info *Common.HostInfo) (tmperr error) {
 						return nil
 					}
 				case <-time.After(time.Duration(Common.Timeout) * time.Second):
-					err = fmt.Errorf("连接超时")
+					err = fmt.Errorf("Connection timeout")
 				}
 
 				if err != nil {
-					errMsg := fmt.Sprintf("IMAP服务 %s 尝试失败 用户名: %v 密码: %v 错误: %v", target, user, pass, err)
+					errMsg := fmt.Sprintf("IMAP service %s attempt failed Username: %v Password: %v Error: %v", target, user, pass, err)
 					Common.LogError(errMsg)
 
 					if retryErr := Common.CheckErrs(err); retryErr != nil {
@@ -100,17 +100,17 @@ func IMAPScan(info *Common.HostInfo) (tmperr error) {
 		}
 	}
 
-	Common.LogDebug(fmt.Sprintf("扫描完成，共尝试 %d 个组合", tried))
+	Common.LogDebug(fmt.Sprintf("Scan complete, tried %d combinations", tried))
 	return tmperr
 }
 
-// IMAPConn 连接测试函数
+// IMAPConn connection test function
 func IMAPConn(info *Common.HostInfo, user string, pass string) (bool, error) {
 	host, port := info.Host, info.Ports
 	timeout := time.Duration(Common.Timeout) * time.Second
 	addr := fmt.Sprintf("%s:%s", host, port)
 
-	// 尝试普通连接
+	// Attempt plain connection
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err == nil {
 		if flag, err := tryIMAPAuth(conn, user, pass, timeout); err == nil {
@@ -119,33 +119,33 @@ func IMAPConn(info *Common.HostInfo, user string, pass string) (bool, error) {
 		conn.Close()
 	}
 
-	// 尝试TLS连接
+	// Attempt TLS connection
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
 	}
 	conn, err = tls.DialWithDialer(&net.Dialer{Timeout: timeout}, "tcp", addr, tlsConfig)
 	if err != nil {
-		return false, fmt.Errorf("连接失败: %v", err)
+		return false, fmt.Errorf("Connection failed: %v", err)
 	}
 	defer conn.Close()
 
 	return tryIMAPAuth(conn, user, pass, timeout)
 }
 
-// tryIMAPAuth 尝试IMAP认证
+// tryIMAPAuth attempts IMAP authentication
 func tryIMAPAuth(conn net.Conn, user string, pass string, timeout time.Duration) (bool, error) {
 	conn.SetDeadline(time.Now().Add(timeout))
 
 	reader := bufio.NewReader(conn)
 	_, err := reader.ReadString('\n')
 	if err != nil {
-		return false, fmt.Errorf("读取欢迎消息失败: %v", err)
+		return false, fmt.Errorf("Failed to read welcome message: %v", err)
 	}
 
 	loginCmd := fmt.Sprintf("a001 LOGIN \"%s\" \"%s\"\r\n", user, pass)
 	_, err = conn.Write([]byte(loginCmd))
 	if err != nil {
-		return false, fmt.Errorf("发送登录命令失败: %v", err)
+		return false, fmt.Errorf("Failed to send login command: %v", err)
 	}
 
 	for {
@@ -153,9 +153,9 @@ func tryIMAPAuth(conn net.Conn, user string, pass string, timeout time.Duration)
 		response, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
-				return false, fmt.Errorf("认证失败")
+				return false, fmt.Errorf("Authentication failed")
 			}
-			return false, fmt.Errorf("读取响应失败: %v", err)
+			return false, fmt.Errorf("Failed to read response: %v", err)
 		}
 
 		if strings.Contains(response, "a001 OK") {
@@ -163,7 +163,7 @@ func tryIMAPAuth(conn net.Conn, user string, pass string, timeout time.Duration)
 		}
 
 		if strings.Contains(response, "a001 NO") || strings.Contains(response, "a001 BAD") {
-			return false, fmt.Errorf("认证失败")
+			return false, fmt.Errorf("Authentication failed")
 		}
 	}
 }

--- a/Plugins/Memcached.go
+++ b/Plugins/Memcached.go
@@ -7,29 +7,29 @@ import (
 	"time"
 )
 
-// MemcachedScan 检测Memcached未授权访问
+// MemcachedScan checks for unauthorized access to Memcached
 func MemcachedScan(info *Common.HostInfo) error {
 	realhost := fmt.Sprintf("%s:%v", info.Host, info.Ports)
 	timeout := time.Duration(Common.Timeout) * time.Second
 
-	// 建立TCP连接
+	// Establish TCP connection
 	client, err := Common.WrapperTcpWithTimeout("tcp", realhost, timeout)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	// 设置超时时间
+	// Set timeout
 	if err := client.SetDeadline(time.Now().Add(timeout)); err != nil {
 		return err
 	}
 
-	// 发送stats命令
+	// Send stats command
 	if _, err := client.Write([]byte("stats\n")); err != nil {
 		return err
 	}
 
-	// 读取响应
+	// Read response
 	rev := make([]byte, 1024)
 	n, err := client.Read(rev)
 	if err != nil {
@@ -37,9 +37,9 @@ func MemcachedScan(info *Common.HostInfo) error {
 		return err
 	}
 
-	// 检查响应内容
+	// Check response content
 	if strings.Contains(string(rev[:n]), "STAT") {
-		// 保存结果
+		// Save result
 		result := &Common.ScanResult{
 			Time:   time.Now(),
 			Type:   Common.VULN,
@@ -53,7 +53,7 @@ func MemcachedScan(info *Common.HostInfo) error {
 			},
 		}
 		Common.SaveResult(result)
-		Common.LogSuccess(fmt.Sprintf("Memcached %s 未授权访问", realhost))
+		Common.LogSuccess(fmt.Sprintf("Memcached %s unauthorized access", realhost))
 	}
 
 	return nil


### PR DESCRIPTION
Translate Chinese text to English in various plugin files.

* **Plugins/FTP.go**
  - Translate log messages and comments from Chinese to English.
  - Update function comments to English.

* **Plugins/IMAP.go**
  - Translate log messages and comments from Chinese to English.
  - Update function comments to English.

* **Plugins/Kafka.go**
  - Translate log messages and comments from Chinese to English.
  - Update function comments to English.

* **Plugins/LDAP.go**
  - Translate log messages and comments from Chinese to English.
  - Update function comments to English.

* **Plugins/Memcached.go**
  - Translate log messages and comments from Chinese to English.
  - Update function comments to English.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/redhawkeye/fscan/pull/2?shareId=1ae59b9a-81ba-416d-8d45-ab14c5e958ea).